### PR TITLE
Topkg.Pkg.test was only introduced in 0.7.4

### DIFF
--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ build-test: [
 ]
 depends: [
   "ocamlfind" {build}
-  "topkg"     {build & >= "0.7.2"}
+  "topkg"     {build & >= "0.7.4"}
   "alcotest" {test}
   "base-bytes"
   "ctypes" {>= "0.4.0"}


### PR DESCRIPTION
Introduced in #4.
