### PR TITLE
Update lwt.preemptive findlib refs to lwt.unix

### DIFF
--- a/_tags
+++ b/_tags
@@ -8,6 +8,6 @@ true: principal, bin_annot, safe_string, strict_sequence, debug
 <lib/cf_stubs.c>: use_ctypes, use_cf_util
 <lib/*.{cma,cmxa,cmxs}>: use_cf_stubs
 
-<lwt/*.*>: package(lwt.preemptive), thread
+<lwt/*.*>: package(lwt.unix), thread
 
 <test/*>: package(alcotest)

--- a/lib_test/_tags
+++ b/lib_test/_tags
@@ -1,1 +1,1 @@
-<*.*>: package(alcotest), package(ctypes.stubs), package(ctypes.foreign), package(lwt.preemptive), use_cf_stubs, thread
+<*.*>: package(alcotest), package(ctypes.stubs), package(ctypes.foreign), package(lwt.unix), use_cf_stubs, thread

--- a/opam
+++ b/opam
@@ -26,7 +26,7 @@ depends: [
   "ctypes-foreign"
 ]
 depopts: [
-  "lwt"
+  "lwt" {>= "3.2.0"}
   "base-threads"
 ]
 available: [os = "darwin"]

--- a/pkg/META
+++ b/pkg/META
@@ -9,7 +9,7 @@ exists_if = "osx-cf.cma"
 
 package "lwt" (
   version = "%%VERSION%%"
-  requires = "osx-cf lwt.preemptive"
+  requires = "osx-cf lwt.unix"
   description = "Lwt bindings to OS X CoreFoundation system library bindings"
   archive(byte) = "osx-cf-lwt.cma"
   archive(native) = "osx-cf-lwt.cmxa"


### PR DESCRIPTION
As per https://github.com/ocsigen/lwt/issues/453 - In newer `lwt` versions, `lwt.preemptive` is gone as an independent package and now lives in `lwt.unix` - this updates the references.